### PR TITLE
Center mosaic title block on load

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,6 +100,34 @@ html, body {
 .mosaic-item.tall { grid-row: span 2; }
 .mosaic-item.big  { grid-column: span 2; grid-row: span 2; }
 
+.title-block {
+  background: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-family: 'Source Sans 3', sans-serif;
+  width: 100%;
+  max-width: 600px;
+  padding: 1rem;
+  box-sizing: border-box;
+  justify-self: center;
+}
+.title-block h1 {
+  font-family: 'Red Rose', 'Source Sans 3', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: 2px;
+}
+.title-block h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0.5rem 0 0;
+}
+
 .vignette {
   position: fixed;
   inset: 0;
@@ -112,44 +140,6 @@ html, body {
   mix-blend-mode: multiply;
 }
 
-.center-image {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 250px;
-  pointer-events: none;
-  z-index: 10;
-}
-
-.center-text {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
-  color: #fff;
-  font-family: 'Source Sans 3', sans-serif;
-  z-index: 10;
-  pointer-events: none;
-  transition: opacity 0.4s;
-}
-
-.center-text h1 {
-  font-family: 'Red Rose', 'Source Sans 3', sans-serif;
-  font-size: 4rem;
-  font-weight: 700;
-  margin: 0;
-  letter-spacing: 3px;
-  text-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
-}
-
-.center-text h2 {
-  font-size: 2rem;
-  font-weight: 600;
-  margin: 0.75rem 0 0;
-  text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
-}
 
 
 .edge-fade {

--- a/test.html
+++ b/test.html
@@ -15,10 +15,6 @@
   </div>
   <div class="vignette"></div>
   <div class="edge-fade"></div>
-  <div class="center-text">
-    <h1>LA BANDE À FEMTO</h1>
-    <h2>VOTRE BANDE DÉMO SUR-MESURE</h2>
-  </div>
 
 
 
@@ -27,14 +23,27 @@
     const mosaic = document.querySelector('.mosaic');
     const vignette = document.querySelector('.vignette');
     const edgeFade = document.querySelector('.edge-fade');
-    const centerText = document.querySelector('.center-text');
+
+    function createTitleBlock() {
+      const block = document.createElement('div');
+      block.classList.add('mosaic-item', 'title-block', 'big');
+      block.innerHTML = '<h1>LA BANDE À FEMTO</h1><h2>VOTRE BANDE DÉMO SUR-MESURE</h2>';
+      return block;
+    }
 
     fetch('images/image_list.json')
       .then(r => r.json())
       .then(list => {
         list.sort(() => Math.random() - 0.5);
+        const midIndex = Math.floor(list.length / 2);
         const sizeClasses = ['big', 'tall', 'wide'];
-        list.forEach(path => {
+        const titleBlock = createTitleBlock();
+        let inserted = false;
+        list.forEach((path, i) => {
+          if (i === midIndex) {
+            mosaic.appendChild(titleBlock);
+            inserted = true;
+          }
           const item = document.createElement('div');
           item.classList.add('mosaic-item');
           if (Math.random() < 0.3) {
@@ -45,17 +54,21 @@
           item.appendChild(img);
           mosaic.appendChild(item);
         });
+        if (!inserted) {
+          mosaic.appendChild(titleBlock);
+        }
+
+        requestAnimationFrame(() => {
+          const offset = titleBlock.offsetTop - mosaic.clientHeight / 2 + titleBlock.clientHeight / 2;
+          mosaic.scrollTop = Math.max(0, offset);
+          updateUI();
+        });
       });
 
     function updateUI() {
       const ratio = Math.min(mosaic.scrollTop / 200, 1);
       vignette.style.opacity = 1 - 0.8 * ratio;
       edgeFade.style.opacity = 1 - ratio;
-      if (ratio > 0.3) {
-        centerText.style.opacity = 0;
-      } else {
-        centerText.style.opacity = 1;
-      }
     }
 
     mosaic.addEventListener('scroll', updateUI);


### PR DESCRIPTION
## Summary
- keep title tile narrow and centered
- remove unused overlay CSS
- auto-scroll mosaic so the title block is visible on page load

## Testing
- `python3 -m py_compile scripts/generate_image_list.py`


------
https://chatgpt.com/codex/tasks/task_e_6876d14ab418832186f770b81aefb042