### PR TITLE
Insert title block into mosaic and clean styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -145,34 +145,6 @@ html, body {
   z-index: 10;
 }
 
-.center-text {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
-  color: #fff;
-  font-family: 'Source Sans 3', sans-serif;
-  z-index: 10;
-  pointer-events: none;
-  transition: opacity 0.4s;
-}
-
-.center-text h1 {
-  font-family: 'Red Rose', 'Source Sans 3', sans-serif;
-  font-size: 4rem;
-  font-weight: 700;
-  margin: 0;
-  letter-spacing: 3px;
-  text-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
-}
-
-.center-text h2 {
-  font-size: 2rem;
-  font-weight: 600;
-  margin: 0.75rem 0 0;
-  text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
-}
 
 
 .edge-fade {

--- a/test.html
+++ b/test.html
@@ -15,22 +15,32 @@
   </div>
   <div class="vignette"></div>
   <div class="edge-fade"></div>
-  <div class="center-text">
-    <h1>LA BANDE À FEMTO</h1>
-    <h2>VOTRE BANDE DÉMO SUR-MESURE</h2>
-  </div>
 
   <script>
     const mosaic = document.querySelector('.mosaic');
     const vignette = document.querySelector('.vignette');
     const edgeFade = document.querySelector('.edge-fade');
 
+    function createTitleBlock() {
+      const block = document.createElement('div');
+      block.classList.add('mosaic-item', 'title-block', 'big');
+      block.innerHTML = `
+        <h1>LA BANDE À FEMTO</h1>
+        <h2>VOTRE BANDE DÉMO SUR-MESURE</h2>
+      `;
+      return block;
+    }
+
     fetch('images/image_list.json')
       .then(r => r.json())
       .then(list => {
         list.sort(() => Math.random() - 0.5);
+        const insertIndex = Math.floor(list.length / 2);
         const sizeClasses = ['big', 'tall', 'wide'];
         list.forEach((path, i) => {
+          if (i === insertIndex) {
+            mosaic.appendChild(createTitleBlock());
+          }
           const item = document.createElement('div');
           item.classList.add('mosaic-item');
           if (Math.random() < 0.3) {


### PR DESCRIPTION
## Summary
- remove unused `.center-text` markup and CSS
- add `createTitleBlock` helper to insert a title tile
- drop obsolete `.center-text` rules from `style.css`

## Testing
- `python3 -m py_compile scripts/generate_image_list.py`

------
https://chatgpt.com/codex/tasks/task_e_6876dbfb98408321ac4c99f3dcb625cd