### PR TITLE
Add text outlines and scroll fade for header

### DIFF
--- a/style.css
+++ b/style.css
@@ -120,6 +120,7 @@ html, body {
   margin: 0;
   letter-spacing: 2px;
   text-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+  -webkit-text-stroke: 2px #ffffff;
 }
 
 .center-text h2 {
@@ -127,6 +128,7 @@ html, body {
   font-weight: 600;
   margin: 0.5rem 0 0;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
+  -webkit-text-stroke: 1px #ffffff;
 }
 
 .vignette {

--- a/test.html
+++ b/test.html
@@ -23,6 +23,7 @@
     const mosaic = document.querySelector('.mosaic');
     const vignette = document.querySelector('.vignette');
     const edgeFade = document.querySelector('.edge-fade');
+    const centerText = document.querySelector('.center-text');
 
     fetch('images/image_list.json')
       .then(r => r.json())
@@ -42,11 +43,12 @@
         });
       });
 
-    function updateUI() {
-      const ratio = Math.min(mosaic.scrollTop / 200, 1);
-      vignette.style.opacity = 1 - 0.8 * ratio;
-      edgeFade.style.opacity = 1 - ratio;
-    }
+      function updateUI() {
+        const ratio = Math.min(mosaic.scrollTop / 200, 1);
+        vignette.style.opacity = 1 - 0.8 * ratio;
+        edgeFade.style.opacity = 1 - ratio;
+        centerText.style.opacity = 1 - ratio;
+      }
 
     mosaic.addEventListener('scroll', updateUI);
     updateUI();


### PR DESCRIPTION
## Summary
- outline the header text so it stands out
- fade header text away as mosaic scrolls

## Testing
- `python3 -m py_compile scripts/generate_image_list.py`

------
https://chatgpt.com/codex/tasks/task_e_6876e68ededc83218c31e0da3b9443c5